### PR TITLE
feat(workflows): trigger the workflow when a pull request is closed i…

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -1,6 +1,9 @@
 name: Attach Artifact to Release
 
 on:
+  pull_request:
+    types:
+      - closed
   push:
     branches:
       - main


### PR DESCRIPTION
…n addition to push events on the main branch

The workflow "Attach Artifact to Release" will now be triggered not only when there is a push event on the main branch, but also when a pull request is closed. This change allows for better automation and ensures that artifacts are attached to releases even when pull requests are merged or closed.