### PR TITLE
fix(DAT-22713): pin all GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Validate PR Labels
-        uses: mheap/github-action-required-labels@v5
+        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5.5.2
         with:
           mode: minimum
           count: 1


### PR DESCRIPTION
## Summary
- Pins all third-party GitHub Action references to immutable commit SHAs
- Uses `@SHA # vX.Y.Z` format so Dependabot can continue tracking version updates
- Follows canonical SHA list maintained in liquibase/build-logic

## Security Impact
Prevents supply chain attacks where a compromised action maintainer could silently repoint a mutable version tag to inject malicious code into workflows.

## Test Plan
- [ ] Verify no unpinned tags remain: `grep -rn 'uses:.*@v[0-9]' .github/` returns zero results
- [ ] Workflow syntax is valid

Closes DAT-22713. Part of DAT-21269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)